### PR TITLE
Added support for https secure connection to play.google.com.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,22 @@ You can verify everything is working by running the scripts manually from the co
     $ ./cmd_playPause.sh
 
 Finally, wire up the shortcuts scripts to your desktop environment, usually under keyboard settings.  For example, in Ubuntu I found them under Applications > System Tools > Preferences > Cinnamon Settings > Keyboard > Keyboard shortcuts > Custom Shortcuts.
+
+
+HTTPS usage notes
+-----------------
+
+Google Play music now uses https. This requires you to generate self-signed ssl
+certificates as described here:
+http://docs.nodejitsu.com/articles/HTTP/servers/how-to-create-a-HTTPS-server
+
+You can place key.pem and cert.pen directly in ssl-certificates/.
+
+Notes
+-----
+
+To get the chrome console:
+    Ctrl + Shift + J
+
+To re-package the extension:
+    ./make_crx.sh playplay_ext/ ~/.ssh/id_rsa

--- a/cmd.sh
+++ b/cmd.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 cmd=`expr match "$0" '.*cmd_\(.*\).sh'`
-curl -s http://localhost:8076/${cmd} > /dev/null
+curl -ks https://localhost:8076/${cmd} > /dev/null

--- a/playplay_ext/playplay_client.js
+++ b/playplay_ext/playplay_client.js
@@ -50,8 +50,11 @@ function getElementWithAttr(attr, value) {
   return null;
 }
 
-var ws = new WebSocket('ws://localhost:6589');
+// Use secure websockets.
+var ws = new WebSocket('wss://localhost:6589');
+
 ws.onmessage = function (event) {
+    console.log("got event " + event.data);
     if (event.data == "playPause") {
         dispatchClick(getElementWithAttr("data-id", "play-pause"));
     } else if (event.data == "prevTrack") {


### PR DESCRIPTION
I updated the extension and server to handle the (now) secure connection to https://play.google.com. It's very likely there's a much, much better way to do this.

Since this requires generating self-signed SSL certificates, I added some instructions to the README.
